### PR TITLE
Fix user settings 409 conflict error

### DIFF
--- a/src/services/dataLayer.ts
+++ b/src/services/dataLayer.ts
@@ -269,10 +269,13 @@ export class DataLayer {
 
       const { error } = await supabase
         .from('user_settings')
-        .upsert({
-          user_id: user.user.id,
-          sort_mode: mode
-        });
+        .upsert(
+          {
+            user_id: user.user.id,
+            sort_mode: mode
+          },
+          { onConflict: 'user_id' }
+        );
 
       if (error) {
         console.error('Error saving sort mode:', error);
@@ -317,10 +320,13 @@ export class DataLayer {
 
       const { error } = await supabase
         .from('user_settings')
-        .upsert({
-          user_id: user.user.id,
-          accent_color: color
-        });
+        .upsert(
+          {
+            user_id: user.user.id,
+            accent_color: color
+          },
+          { onConflict: 'user_id' }
+        );
 
       if (error) {
         console.error('Error saving accent color:', error);
@@ -337,11 +343,14 @@ export class DataLayer {
 
       const { error } = await supabase
         .from('user_settings')
-        .insert({
-          user_id: user.user.id,
-          sort_mode: 'chronological',
-          accent_color: '46 87% 65%'
-        });
+        .upsert(
+          {
+            user_id: user.user.id,
+            sort_mode: 'chronological',
+            accent_color: '46 87% 65%'
+          },
+          { onConflict: 'user_id' }
+        );
 
       if (error) {
         console.error('Error creating default settings:', error);


### PR DESCRIPTION
Update `user_settings` writes to use upsert with `onConflict: 'user_id'` to prevent 409 conflict errors.

The `user_settings` table has a unique constraint on `user_id`. Previously, `insert` was used for default settings, and existing `upsert` calls did not specify `onConflict`, leading to 409 conflicts when attempting to create or update settings for an existing user.

---
<a href="https://cursor.com/background-agent?bcId=bc-aa60fdeb-7723-4a35-8c27-f974fc326a73">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-aa60fdeb-7723-4a35-8c27-f974fc326a73">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

